### PR TITLE
meson: On Linux when compiling with gcc, use zlib.map

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,11 +1,21 @@
 project('zlib', 'c', version : '1.2.11', license : 'zlib')
 
+link_args = []
+
+cc = meson.get_compiler('c')
+
+if cc.get_id() == 'gcc' and host_machine.system() == 'linux'
+  vflag = '-Wl,--version-script,@0@/zlib.map'.format(meson.current_source_dir())
+  link_args += [vflag]
+endif
+
 src = ['adler32.c', 'crc32.c', 'deflate.c', 'infback.c', 'inffast.c', 'inflate.c',
 'inftrees.c', 'trees.c', 'zutil.c',
 'compress.c', 'uncompr.c', 'gzclose.c', 'gzlib.c', 'gzread.c', 'gzwrite.c']
 
 zlib = library('z', src,
   c_args : ['-DZLIB_DLL'],
+  link_args : link_args,
   install : true,
   version : meson.project_version())
 


### PR DESCRIPTION
I was playing around with my alwaysfallback wrap mode and encountered issues with symbol visibility, as mentioned in the port commit, I don't know whether that's the best way to handle it but it's non intrusive and worksforme :)